### PR TITLE
Minor: fix highlighting in "query clause" step of code tour

### DIFF
--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -34,7 +34,7 @@
         },
         "end": {
           "line": 8,
-          "character": 8
+          "character": 9
         }
       }
     },


### PR DESCRIPTION
Extends the highlighting, so that we also select the `p`! 

![image](https://user-images.githubusercontent.com/42641846/212894802-d7412527-b176-469c-8d70-32aed273a3df.png)
