### PR TITLE
Set current database automatically

### DIFF
--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -12,7 +12,7 @@
     },
     {
       "directory": "codeql-tutorial-database",
-      "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database. You can see this is selected by going to the CodeQL extension and checking that `codeql-tutorial-database` is present in the `Databases` panel. From here you are able to select a different database by right-clicking on it and choosing `Set Current Database`",
+      "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database. You can see this is selected by going to the CodeQL extension and checking that `codeql-tutorial-database` is present in the `Databases` panel. From here you are able to select a different database by right-clicking on it and choosing `Set Current Database`.",
       "commands": ["codeQL.setDefaultTourDatabase"]
     },
     {

--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -12,7 +12,7 @@
     },
     {
       "directory": "codeql-tutorial-database",
-      "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database.",
+      "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database. You can see this is selected by going to the CodeQL extension and checking that `codeql-tutorial-database` is present in the `Databases` panel. From here you are able to select a different database by right-clicking on it and choosing `Set Current Database`",
       "commands": ["codeQL.setDefaultTourDatabase"]
     },
     {

--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -12,7 +12,8 @@
     },
     {
       "directory": "codeql-tutorial-database",
-      "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nTo select this as your current database, right-click on the directory, and click `CodeQL: Set Current Database`. Click `Next` when you have done that."
+      "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database.",
+      "commands": ["codeQL.setDefaultTourDatabase"]
     },
     {
       "file": "tutorial-queries/tutorial.ql",


### PR DESCRIPTION
Depends on https://github.com/github/vscode-codeql/pull/2027 getting merged first. 

At the moment we're asking the user to manually right click on
the database folder ('codeql-tutorial-database') and set it as
the current database.

We can take this one step further by defining a command that gets
triggered when we arrive at the step for setting up the database.

The command ("codeQL.setDefaultTourDatabase") will build the URI
pointing to our preloaded database and set it as the current one.

We initially considered whether we can re-use the setCurrentDatabase
command and pass the URI of the database from the codespace itself,
but the URI would be hardcoded as:

```
file://0-62/workspaces/codespaces-codeql/codeql-tutorial-database
```

as we can only pass the codeTour extension a command and string
parameters.

This would have been brittle as the filepath for a codespace might
change in the future.

Instead we can define a custom tour command ("setDefaultTourDatabase")
to look at the current workspace folder and build the path to the
database in the CodeQL extension.