### PR TITLE
Ignore CodeQL metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# CodeQL metadata
+codeql-tutorial-database/db-csv/default/cache/
+.cache/


### PR DESCRIPTION
This is stuff that gets generated when we run queries. We can safely ignore it, [like we do in the CodeQL extension](https://github.com/github/vscode-codeql/blob/c309bdc1b7d213dfa3a885047abe36f6ab3ea598/.gitignore#L20). 