### PR TITLE
Run `packInstall` command for tutorial queries

### DIFF
--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -13,7 +13,7 @@
     {
       "directory": "codeql-tutorial-database",
       "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the `codeql-tutorial-database` directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database. You can see this is selected by going to the CodeQL extension and checking that `codeql-tutorial-database` is present in the `Databases` panel. From here you are able to select a different database by right-clicking on it and choosing `Set Current Database`.",
-      "commands": ["codeQL.setDefaultTourDatabase"]
+      "commands": ["codeQL.setDefaultTourDatabase", "codeQL.packInstall"]
     },
     {
       "file": "tutorial-queries/tutorial.ql",


### PR DESCRIPTION
Follow-up to: https://github.com/github/codespaces-codeql/pull/6

This PR will trigger a `codeql pack install` command in order to install 
real library dependencies for `tutorial-queries`, since we no longer 
have the dummy library in `tutorial-lib`.