### PR TITLE
Make sure we install packs compatible with our CLI

### DIFF
--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -1,0 +1,2 @@
+provide:
+  - "*/codeql-packs/**/qlpack.yml"


### PR DESCRIPTION
Docs: https://docs.github.com/en/code-security/codeql-cli/codeql-cli-reference/about-codeql-workspaces#the-codeql-workspaceyml-file

We've introduced some changes to run `codeql pack install` from:
-  the `tutorial-queries` folder (the folder is a QL pack)
- any skeleton QL pack generated when you add a new database.

This manifest allows us to tell the `codeql pack install` command to try to resolve packages from within the workspace.