### PR TITLE
Trigger query in the background for tutorial step

### DIFF
--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -62,7 +62,10 @@
           "character": 1
         }
       },
-      "title": "Run Query"
+      "title": "Run Query",
+      "commands": [
+        "codeQL.runQuery"
+      ]
     },
     {
       "file": "tutorial-queries/tutorial.ql",


### PR DESCRIPTION
We missed this when [we re-organised the steps](https://github.com/github/codespaces-codeql/pull/8/files#diff-93c80ad6d5bc4219c4759cbd66c29b663561ad6c9895377a039c2ff13bde3c58L70).