### PR TITLE
Run `pack install` via tour command - take 2

### DIFF
--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -14,7 +14,10 @@
       "directory": ".tours/codeql-tutorial-database",
       "description": "To run a CodeQL query, we need to select a CodeQL database.\n\nWe have prepared a sample database for you to use in this tutorial.\nLook for the 'codeql-tutorial-database' directory highlighted in the Explorer view in your left sidebar.\n\nWe have selected this as your current database.",
       "commands": [
-        "codeQL.setDefaultTourDatabase"
+        "codeQL.setDefaultTourDatabase",
+        "codetour.sendTextToTerminal?[\"cd tutorial-queries\"]",
+        "codetour.sendTextToTerminal?[\"codeql pack install\"]",
+        "codetour.sendTextToTerminal?[\"cd ..\"]"
       ],
       "title": "Your first Database"
     },


### PR DESCRIPTION
We initially [created a separate function](https://github.com/github/vscode-codeql/pull/2090/files#diff-b11b6f7e1d76e818f721c94ae740f046663c80d519c2f515f2f78344f90e6c78R405-R420) in the extension to do this.

Turns out we can pass shell commands in the code tour, so we can get rid of the custom function.