### PR TITLE
Install cli on onCreate.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,5 +8,6 @@
       "openFiles": ["README.md"]
     }
   },
+  "onCreateCommand": "bash .devcontainer/onCreateCommand.sh",
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Assumes the gh CLI is present in the default Codespaces image.
+gh extensions install github/gh-codeql
+gh codeql version # first command starts the download
+gh codeql install-stub ~/.local/bin/

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -2,5 +2,6 @@
 
 # Assumes the gh CLI is present in the default Codespaces image.
 gh extensions install github/gh-codeql
-gh codeql version # first command starts the download
+gh codeql version # first command starts the download of the CodeQL CLI
+# Make codeql visible to VSCode by using https://github.com/github/gh-codeql#codeql-stub, since VS Code expects an executable called codeql instead of gh codeql
 gh codeql install-stub ~/.local/bin/

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Assumes the gh CLI is present in the default Codespaces image.
-# gh extensions install github/gh-codeql
-# gh codeql version # first command starts the download
-
 # Copy the dbscheme into the tutorial library, so it matches the DB.
 cp .tours/codeql-tutorial-database/db-csv/csv.dbscheme tutorial-queries/
 cp .tours/codeql-tutorial-database/db-csv/csv.dbscheme.stats tutorial-queries/


### PR DESCRIPTION
This PR adds installing a version of CodeQL to the codespace. Instead of adding that to the `postCreateCommand` we instead add it to the `onCreateCommand` this should mean that it gets run as part of prebuilds (see https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds#configuring-time-consuming-tasks-to-be-included-in-the-prebuild), and therefore mean that the user should not need to wait for that if we set up prebuilds.

I turned on prebuilds for this branch (`post-install-cli`) so that we can see it in action on that branch.
See https://github.com/github/codespaces-codeql/actions/runs/4302995295/jobs/7502182118#step:4:254 for when it downloads CLI during prebuild.

After merging this we should setup prebuilds for main.
