### PR TITLE
Install tutorial pack dependencies in codespace prebuild

### DIFF
--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -5,3 +5,9 @@ gh extensions install github/gh-codeql
 gh codeql version # first command starts the download of the CodeQL CLI
 # Make codeql visible to VSCode by using https://github.com/github/gh-codeql#codeql-stub, since VS Code expects an executable called codeql instead of gh codeql
 gh codeql install-stub ~/.local/bin/
+
+# Install the tutorial-queries pack
+cd tutorial-queries
+echo "Installing tutorial-queries pack"
+gh codeql pack install
+cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 .tours/codeql-tutorial-database/db-csv/default/cache/
 .tours/codeql-tutorial-database/db-csv/default/strings/
 .cache/
-
-tutorial-queries/codeql-pack.lock.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tours/codeql-tutorial-database/db-csv/default/strings/
 .cache/
 
+tutorial-queries/codeql-pack.lock.yml

--- a/tutorial-queries/codeql-pack.lock.yml
+++ b/tutorial-queries/codeql-pack.lock.yml
@@ -1,0 +1,6 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/tutorial:
+    version: 0.0.4
+compiled: false


### PR DESCRIPTION
Instead of installing the tutorial-queries pack dependencies during the code tour, we can do this in the prebuild step.

- Confirmed that there are no errors in the prebuild output: https://github.com/github/codespaces-codeql/actions/runs/4325012444/jobs/7550599723#step:4:298
- Confirmed that the pack dependencies are installed when opening a fresh codespace from this branch


See internal linked issue for additional info + follow-up tidying.

