### PR TITLE
Fix warning in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,5 @@
       "openFiles": ["README.md"]
     }
   },
-  "onCreateCommand": "bash .devcontainer/onCreateCommand.sh",
-  "postCreateCommand": "bash .devcontainer/postCreateCommand.sh"
+  "onCreateCommand": "bash .devcontainer/onCreateCommand.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,11 @@
 {
-  "extensions": [
-    "github.vscode-codeql",
-    "vsls-contrib.codetour"
-  ],
-   "customizations": {
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.vscode-codeql",
+        "vsls-contrib.codetour"
+      ],
+    },
     "codespaces": {
       "openFiles": ["README.md"]
     }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Copy the dbscheme into the tutorial library, so it matches the DB.
-cp .tours/codeql-tutorial-database/db-csv/csv.dbscheme tutorial-queries/
-cp .tours/codeql-tutorial-database/db-csv/csv.dbscheme.stats tutorial-queries/


### PR DESCRIPTION
It looks like the `"extensions"` property has changed to `"customizations/vscode/extensions"`:
![image](https://user-images.githubusercontent.com/42641846/225960150-42ab8ff9-b144-4096-ac23-83d974fab03a.png)


This PR updates our `devcontainer.json` to match that format. 