### PR TITLE
Change tour to suggest using new `Create Query` command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
       "extensions": [
         "github.vscode-codeql",
         "vsls-contrib.codetour"
-      ],
+      ]
     },
     "codespaces": {
       "openFiles": ["README.md"]

--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -107,7 +107,7 @@
     },
     {
       "file": "tutorial-queries/tutorial.ql",
-      "description": "It's time to add your own database and analyze some real code!\n\nBring up the command pallete (Cmd/Ctrl + P) and type '> CodeQL: Create Query'. Choose the language of your favorite open source repository.\nAfterwards, you will be asked to provide the name of your repo so we can download the CodeQL database for it. You can either type your preferred repo or go with the suggestion we've provided. When the download has finished, the database will be automatically selected.",
+      "description": "It's time to create your own query and analyze some real code!\n\n1. Open the Command Palette with `Cmd/Ctrl+Shift+P` and type 'CodeQL: Create Query'.\n2. Choose the language that you'd like to analyze.\n3. Type the name of a repository with that language, so that we can download the CodeQL database for it.\n\n When the download has finished, the database will be automatically selected, so you can immediately modify and run your query!",
       "selection": {
         "start": {
           "line": 7,
@@ -118,7 +118,7 @@
           "character": 1
         }
       },
-      "title": "Add your own database",
+      "title": "Add your own query",
       "view": "codeQLDatabases"
     },
     {

--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -107,7 +107,7 @@
     },
     {
       "file": "tutorial-queries/tutorial.ql",
-      "description": "It's time to add your own database and analyze some real code!\n\nHover over the 'Databases' title bar and click 'Download Database from GitHub'. Enter the repository name of your favorite open source repository.\nAfter the download has finished, the database will be automatically selected.",
+      "description": "It's time to add your own database and analyze some real code!\n\nBring up the command pallete (Cmd/Ctrl + P) and type '> CodeQL: Create Query'. Choose the language of your favorite open source repository.\nAfterwards, you will be asked to provide the name of your repo so we can download the CodeQL database for it. You can either type your preferred repo or go with the suggestion we've provided. When the download has finished, the database will be automatically selected.",
       "selection": {
         "start": {
           "line": 7,

--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -106,18 +106,7 @@
       "title": "Run query yourself"
     },
     {
-      "file": "tutorial-queries/tutorial.ql",
       "description": "It's time to create your own query and analyze some real code!\n\n1. Open the Command Palette with `Cmd/Ctrl+Shift+P` and type 'CodeQL: Create Query'.\n2. Choose the language that you'd like to analyze.\n3. Type the name of a repository with that language, so that we can download the CodeQL database for it.\n\n When the download has finished, the database will be automatically selected, so you can immediately modify and run your query!",
-      "selection": {
-        "start": {
-          "line": 7,
-          "character": 1
-        },
-        "end": {
-          "line": 9,
-          "character": 1
-        }
-      },
       "title": "Add your own query",
       "view": "codeQLDatabases"
     },

--- a/.tours/codeql-tutorial.tour
+++ b/.tours/codeql-tutorial.tour
@@ -109,11 +109,6 @@
       "description": "It's time to create your own query and analyze some real code!\n\n1. Open the Command Palette with `Cmd/Ctrl+Shift+P` and type 'CodeQL: Create Query'.\n2. Choose the language that you'd like to analyze.\n3. Type the name of a repository with that language, so that we can download the CodeQL database for it.\n\n When the download has finished, the database will be automatically selected, so you can immediately modify and run your query!",
       "title": "Add your own query",
       "view": "codeQLDatabases"
-    },
-    {
-      "title": "CodeQL pack",
-      "description": "After adding a database we create a new CodeQL pack for you.\n\nThis loads all dependencies needed for the language of the database, and creates an example query that you can run and modify.\n\nOpen `example.ql` inside the 'codeql-custom-queries-*' folder to get started.",
-      "view": "explorer"
     }
   ]
 }

--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -1,2 +1,3 @@
 provide:
   - "tutorial-queries/codeql-pack.yml"
+  - "codeql-custom-queries-*/codeql-pack.yml"

--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -1,2 +1,2 @@
 provide:
-  - "*/codeql-packs/**/qlpack.yml"
+  - "tutorial-queries/codeql-pack.yml"


### PR DESCRIPTION
We're now generating a query pack through the CodeQL: Create Query command. [1]

We should change the tour to suggest you use this new command to generate a query + skeleton pack.

[1]: https://github.com/github/code-scanning/issues/9358