### PR TITLE
Make sure that the "tutorial-queries" pack is available in the workspace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
       "extensions": [
         "github.vscode-codeql",
         "vsls-contrib.codetour"
-      ],
+      ]
     },
     "codespaces": {
       "openFiles": ["README.md"]

--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -1,2 +1,2 @@
 provide:
-  - "*/codeql-packs/**/qlpack.yml"
+  - "tutorial-queries/codeql-pack.yml"


### PR DESCRIPTION
I've updated the [`codeql-workspace.yml`](https://docs.github.com/en/code-security/codeql-cli/codeql-cli-reference/about-codeql-workspaces#the-codeql-workspaceyml-file) file to include the tutorial pack. This means that the repo/workspace is aware of this pack and no longer shows `module cannot be resolved` errors ⏰ 

I've deleted `*/codeql-packs/**/qlpack.yml` from `codeql-workspace.yml` since we don't expect packs at that location (as far as I'm aware). In future, if we generate new subfolders (like `codeql-custom-queries-xxx`), we might need to add those paths to the `codeql-workspace.yml` file.