### PR TITLE
Don't prompt to download database for this repo

### DIFF
--- a/tutorial.code-workspace
+++ b/tutorial.code-workspace
@@ -5,6 +5,7 @@
 		}
 	],
 	"settings":	{
-		"codeQL.codespacesTemplate": true
+		"codeQL.codespacesTemplate": true,
+		"codeQL.githubDatabase.download": "never"
 	}	
 }

--- a/tutorial.code-workspace
+++ b/tutorial.code-workspace
@@ -6,6 +6,6 @@
 	],
 	"settings":	{
 		"codeQL.codespacesTemplate": true,
-		"codeQL.githubDatabase.download": "never"
+		"codeQL.githubDatabase.download": "never",
 	}	
 }


### PR DESCRIPTION
The recent changes for a "[repo-centric setup](https://github.com/github/vscode-codeql/pull/3138)" in the extension means that we get a pop-up to download a CodeQL database for the current repository:

![image](https://github.com/github/codespaces-codeql/assets/42641846/185a71aa-1972-42e7-be76-b5387d559f4a)

This somewhat breaks the flow of the code tour tutorial, so I suggest that we disable the prompt in this case. (I can't imagine anyone usefully needing to run queries on `github/codespaces-codeql` for now.)